### PR TITLE
Add nRF52832 support

### DIFF
--- a/Cargo_nrf_ble.toml
+++ b/Cargo_nrf_ble.toml
@@ -10,11 +10,15 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rmk = { version = "0.1.5", features = ["ble", "eeprom", "col2row"]}
+rmk = { git = "https://github.com/HaoboGu/rmk", features = [
+    "{{ nrf_feature }}_ble",
+    "eeprom",
+    "col2row",
+] }
 cortex-m-rt = "0.7.3"
 cortex-m = "0.7.7"
 embassy-nrf = { version = "0.1.0", features = [
-    "nrf52840",
+    "{{ nrf_feature }}",
     "defmt",
     "time-driver-rtc1",
     "unstable-pac",

--- a/README_gen.md
+++ b/README_gen.md
@@ -14,6 +14,7 @@ Keyboard firmware for cortex-m, with layer/dynamic keymap/[vial](https://get.via
 
 - [ ] Check the chip name of `probe-rs` is right, if you don't use `cargo run`, you can skip this step
 
+{% if ble_chip == "nrf52840" %}
 ## For BLE only
 
 To use NRF BLE, you should have [nrf s140 softdevice 7.3.0](https://www.nordicsemi.com/Products/Development-software/s140/download) flashed to nrf52840 first. 
@@ -32,3 +33,23 @@ The following are the detailed steps:
    ```shell
    cargo run --release
    ```
+{% elsif ble_chip == "nrf52832" %}
+## For BLE only
+
+To use NRF BLE, you should have [nrf s132 softdevice 7.3.0](https://www.nordicsemi.com/Products/Development-software/s132/download) flashed to nrf52832 first. 
+
+The following are the detailed steps:
+
+1. Erase the flash:
+   ```shell
+   probe-rs erase --chip nrf52832_xxAA
+   ```
+2. Flash softdevice firmware to flash:
+   ```shell
+   probe-rs download --verify --format hex --chip nRF52832_xxAA s132_nrf52_7.3.0_softdevice.hex
+   ```
+3. Compile, flash and run the example
+   ```shell
+   cargo run --release
+   ```
+{% endif %}

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -45,6 +45,12 @@ choices = [
 ]
 default = "nrf52840"
 
+[conditional.'microcontroller_family == "nrf" && connection == "BLE"'.placeholders.ble_chip]
+type = "string"
+prompt = "Choose your nrf MCU model (Embassy feature name)"
+choices = ["nrf52840", "nrf52832"]
+default = "nrf52840"
+
 [conditional.'microcontroller_family == "stm32"'.placeholders.chip]
 type = "string"
 prompt = "Enter your MCU model(Embassy feature name)"
@@ -92,4 +98,3 @@ ignore = [
     'Cargo_rp.toml',
     'Cargo_nrf.toml',
 ]
-

--- a/memory.x
+++ b/memory.x
@@ -27,7 +27,14 @@ SECTIONS {
         KEEP(*(.boot2));
     } > BOOT2
 } INSERT BEFORE .text;
-{% elsif connection == "BLE" %}
+{% elsif ble_chip == "nrf52832" %}
+MEMORY
+{
+  /* These values correspond to the NRF52832 with Softdevices S132 7.3.0 */
+  FLASH : ORIGIN = 0x26000,    LENGTH = 0x80000 - 0x26000
+  RAM : ORIGIN = 0x20007af8, LENGTH = 0x20010000 - 0x20007af8
+}
+{% elsif ble_chip == "nrf52840" %}
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -9,14 +9,16 @@ let conn_type = variable::get("connection");
 
 let chip = if conn_type == "BLE" {
     variable::set("connection", "BLE");
-    variable::set("chip", "nrf52840_xxAA");
-    "nrf52840"
+    let ble_chip = variable::get("ble_chip");
+    variable::set("chip", ble_chip + "_xxAA");
+    variable::set("nrf_feature", ble_chip);
+    ble_chip
 } else {
     variable::set("connection", "USB");
     variable::get("chip")
 };
 
-if chip == "nrf52840" || chip == "nrf52833" || chip == "nrf52832" || chip == "nrf52840_xxAA" {
+if chip == "nrf52840" || chip == "nrf52833" || chip == "nrf52832" || chip == "nrf52840" {
     variable::set("target", "thumbv7em-none-eabihf");
 }
 else if chip == "nrf52805" || chip == "nrf52810" || chip == "nrf52811" || chip == "nrf52820" {

--- a/src/main_nrf_ble.rs
+++ b/src/main_nrf_ble.rs
@@ -36,10 +36,13 @@ async fn main(spawner: Spawner) {
     nrf_config.gpiote_interrupt_priority = Priority::P2;
     nrf_config.time_interrupt_priority = Priority::P2;
     let p = embassy_nrf::init(nrf_config);
-
+    {% if ble_chip == "nrf52840" %}
     // Pin config
     let (input_pins, output_pins) = config_matrix_pins_nrf!(peripherals: p, input: [P1_00, P1_01, P1_02, P1_03], output: [P1_05, P1_06, P1_07]);
-
+    {% elsif ble_chip == "nrf52832" %}
+    // Pin config
+    let (input_pins, output_pins) = config_matrix_pins_nrf!(peripherals: p, input: [P0_03, P0_04, P0_28, P0_29], output: [P0_07, P0_11, P0_27]);
+    {% endif %}
     let keyboard_usb_config = KeyboardUsbConfig::new(
         0x4c4b,
         0x4643,


### PR DESCRIPTION
This is a work-in-progress pull request. Currently, it points to the RMK git repository instead of the published crate (v0.1.5). Before merging, we need to ensure that an updated crate supporting nRF52832 is published unless linking to the git repository is what you want.

Also, I have a question about the generated .cargo/config.toml for the USB app. It appears that "_xxAA" is missing in the chip identifier. Is this intentional?