### PR TITLE
Chore: Use keyboard name replace default firmware name

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,18 +12,18 @@ install_crate = { crate_name = "cargo-binutils", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["objcopy", "--release", "--", "-O", "ihex", "rmk.hex"]
+args = ["objcopy", "--release", "--", "-O", "ihex", "{{project-name}}.hex"]
 dependencies = ["install-llvm-tools", "flip-link"]
 
 [tasks.uf2]
 command = "python"
 args = [
     "scripts/uf2conv.py",
-    "rmk.hex",
+    "{{project-name}}.hex",
     "-c",
     "-f",
     "xxxxxxxxxx",         # TODO: Use your chip family ID in the uf2conv.py file as -f argument
     "-o",
-    "rmk.uf2",
+    "{{project-name}}.uf2",
 ]
 dependencies = ["objcopy"]

--- a/Makefile_split.toml
+++ b/Makefile_split.toml
@@ -20,7 +20,7 @@ args = [
     "--",
     "-O",
     "ihex",
-    "rmk-central.hex",
+    "{{project-name}}-central.hex",
 ]
 dependencies = ["install-llvm-tools", "flip-link"]
 
@@ -38,7 +38,7 @@ args = [
     "--",
     "-O",
     "ihex",
-    "rmk-peripheral.hex",
+    "{{project-name}}-peripheral.hex",
 ]
 dependencies = ["install-llvm-tools"]
 
@@ -46,12 +46,12 @@ dependencies = ["install-llvm-tools"]
 command = "python"
 args = [
     "scripts/uf2conv.py",
-    "rmk-central.hex",
+    "{{project-name}}-central.hex",
     "-c",
     "-f",
     "xxxxxxxxxx",         # TODO: Use your chip family ID in the uf2conv.py file as -f argument
     "-o",
-    "rmk-central.uf2",
+    "{{project-name}}-central.uf2",
 ]
 dependencies = ["objcopy-central"]
 
@@ -59,12 +59,12 @@ dependencies = ["objcopy-central"]
 command = "python"
 args = [
     "scripts/uf2conv.py",
-    "rmk-peripheral.hex",
+    "{{project-name}}-peripheral.hex",
     "-c",
     "-f",
     "xxxxxxxxxx",         # TODO: Use your chip family ID in the uf2conv.py file as -f argument
     "-o",
-    "rmk-peripheral.uf2",
+    "{{project-name}}-peripheral.uf2",
 ]
 dependencies = ["objcopy-peripheral"]
 

--- a/README_gen.md
+++ b/README_gen.md
@@ -33,6 +33,10 @@ The following are the detailed steps:
    ```shell
    cargo run --release
    ```
+4.(Optional) generate .uf2 firmware
+   ```shell
+   cargo make uf2 --release
+   ```
 {% elsif chip == "nrf52832_xxAA" -%}
 ## For BLE only
 
@@ -51,6 +55,10 @@ The following are the detailed steps:
 3. Compile, flash and run the example
    ```shell
    cargo run --release
+   ```
+4.(Optional) generate .uf2 firmware
+   ```shell
+   cargo make uf2 --release
    ```
 {% elsif chip == "esp32c3" -%}
 ## For BLE only


### PR DESCRIPTION
- default firemware name is rmk.hex or rmk.uf2, if we have more keybords, it's really confict for firmwares so change it to keyboard name.