### PR TITLE
Rebuild the binaries if the keyboard.toml file changes as well

### DIFF
--- a/esp32c3/build.rs
+++ b/esp32c3/build.rs
@@ -8,6 +8,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     // ESP IDE system env

--- a/esp32c3/build.rs
+++ b/esp32c3/build.rs
@@ -8,7 +8,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/esp32c6/build.rs
+++ b/esp32c6/build.rs
@@ -21,7 +21,6 @@ fn main() {
 fn generate_vial_config() {
     // Generated vial config file
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     let out_file = Path::new(&env::var_os("OUT_DIR").unwrap()).join("config_generated.rs");

--- a/esp32c6/build.rs
+++ b/esp32c6/build.rs
@@ -21,6 +21,9 @@ fn main() {
 fn generate_vial_config() {
     // Generated vial config file
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     let out_file = Path::new(&env::var_os("OUT_DIR").unwrap()).join("config_generated.rs");
 
     let p = Path::new("vial.json");

--- a/esp32s3/build.rs
+++ b/esp32s3/build.rs
@@ -8,6 +8,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     // ESP IDE system env

--- a/esp32s3/build.rs
+++ b/esp32s3/build.rs
@@ -8,7 +8,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/nrf52840/build.rs
+++ b/nrf52840/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     // Put `memory.x` in our output directory and ensure it's

--- a/nrf52840/build.rs
+++ b/nrf52840/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/nrf52840_split/build.rs
+++ b/nrf52840_split/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     // Put `memory.x` in our output directory and ensure it's

--- a/nrf52840_split/build.rs
+++ b/nrf52840_split/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/rp2040/build.rs
+++ b/rp2040/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     // Put `memory.x` in our output directory and ensure it's

--- a/rp2040/build.rs
+++ b/rp2040/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/rp2040_split/build.rs
+++ b/rp2040_split/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     // Put `memory.x` in our output directory and ensure it's

--- a/rp2040_split/build.rs
+++ b/rp2040_split/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/stm32/build.rs
+++ b/stm32/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     println!("cargo:rerun-if-changed=keyboard.toml");

--- a/stm32/build.rs
+++ b/stm32/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/stm32f1/build.rs
+++ b/stm32f1/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     println!("cargo:rerun-if-changed=keyboard.toml");

--- a/stm32f1/build.rs
+++ b/stm32f1/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/stm32f103c8/build.rs
+++ b/stm32f103c8/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     println!("cargo:rerun-if-changed=keyboard.toml");

--- a/stm32f103c8/build.rs
+++ b/stm32f103c8/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();

--- a/stm32h7b0vb/build.rs
+++ b/stm32h7b0vb/build.rs
@@ -20,6 +20,9 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
     generate_vial_config();
 
     println!("cargo:rerun-if-changed=keyboard.toml");

--- a/stm32h7b0vb/build.rs
+++ b/stm32h7b0vb/build.rs
@@ -20,7 +20,6 @@ use xz2::read::XzEncoder;
 fn main() {
     // Generate vial config at the root of project
     println!("cargo:rerun-if-changed=vial.json");
-    println!("cargo:rerun-if-changed=vial.json");
     println!("cargo:rerun-if-changed=keyboard.toml");
 
     generate_vial_config();


### PR DESCRIPTION
Basically just ran this:
```
grep -rl "println!(\"cargo:rerun-if-changed=vial.json\");" . | xargs sed -i '' -E '/println!\("cargo:rerun-if-changed=vial.json"\);/{
p
s/([[:space:]]*).*/&\
\1println!("cargo:rerun-if-changed=keyboard.toml");\
/
}'
```

Explanation of the Command:

    grep -rl: Finds all files containing the target line.

    xargs sed -i '' -E: Runs sed in edit mode (-i '') with extended regular expressions (-E).

    /println!\("cargo:rerun-if-changed=vial.json"\);/: Matches the target line.

    { ... }: Groups multiple commands to execute on the matched line.

        p: Prints the original line (useful for debugging).

        s/([[:space:]]*).*/&\n\1println!("cargo:rerun-if-changed=keyboard.toml");/:

            ([[:space:]]*): Captures the indentation (spaces or tabs) at the start of the line.

            .*: Matches the rest of the line.

            &\n\1println!("cargo:rerun-if-changed=keyboard.toml");: Appends a newline (\n), the captured indentation (\1), and the new line.

