### PR TITLE
Fix generated clippy::redundant-static-lifetimes warning

### DIFF
--- a/esp32c3/build.rs
+++ b/esp32c3/build.rs
@@ -46,6 +46,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/esp32c6/build.rs
+++ b/esp32c6/build.rs
@@ -46,6 +46,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/esp32s3/build.rs
+++ b/esp32s3/build.rs
@@ -46,6 +46,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/nrf52840/build.rs
+++ b/nrf52840/build.rs
@@ -83,6 +83,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/nrf52840_split/build.rs
+++ b/nrf52840_split/build.rs
@@ -81,6 +81,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/rp2040/build.rs
+++ b/rp2040/build.rs
@@ -82,6 +82,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/rp2040_split/build.rs
+++ b/rp2040_split/build.rs
@@ -80,6 +80,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/stm32/build.rs
+++ b/stm32/build.rs
@@ -68,6 +68,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/stm32f1/build.rs
+++ b/stm32f1/build.rs
@@ -68,6 +68,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/stm32f103cb/build.rs
+++ b/stm32f103cb/build.rs
@@ -68,6 +68,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/stm32h7b0vb/build.rs
+++ b/stm32h7b0vb/build.rs
@@ -68,6 +68,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }


### PR DESCRIPTION
You may wants to cherry-pick/back-port it in master. 

> This is not ideal. But, I don't like to work with clippy warning...

See https://github.com/Eolu/const-gen/issues/12
See https://github.com/HaoboGu/rmk/pull/345