### PR TITLE
add embassy-embedded-hal to dependencies for stm32 / rp2040

### DIFF
--- a/pico_w/Cargo.toml
+++ b/pico_w/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["pico_w_ble", "rp2040"] }
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
 embassy-rp = { version = "0.8", features = [
     "rp2040",

--- a/pico_w_split/Cargo.toml
+++ b/pico_w_split/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["pico_w_ble", "rp2040", "split"] }
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
 embassy-rp = { version = "0.8", features = [
     "rp2040",

--- a/rp2040/Cargo.toml
+++ b/rp2040/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["rp2040"] }
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
 embassy-rp = { version = "0.8", features = [
     "rp2040",

--- a/rp2040_split/Cargo.toml
+++ b/rp2040_split/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["split", "rp2040"] }
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
 embassy-rp = { version = "0.8", features = [
     "rp2040",

--- a/stm32/Cargo.toml
+++ b/stm32/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 rmk = { version = "0.8" }
 cortex-m = { version = "0.7.7", features = ['critical-section-single-core'] }
 cortex-m-rt = "0.7.5"
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["tick-hz-32_768", "defmt"] }
 embassy-stm32 = { version = "0.4", features = [
     "{{ chip_name }}",

--- a/stm32f1/Cargo.toml
+++ b/stm32f1/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 rmk = { version = "0.8" }
 cortex-m = { version = "0.7.7", features = ['critical-section-single-core'] }
 cortex-m-rt = "0.7.5"
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["tick-hz-32_768"] }
 embassy-stm32 = { version = "0.4", features = [
     "{{ chip_name }}",

--- a/stm32f103cb/Cargo.toml
+++ b/stm32f103cb/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 rmk = { version = "0.8" }
 cortex-m = { version = "0.7.7", features = ['critical-section-single-core'] }
 cortex-m-rt = "0.7.5"
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["tick-hz-32_768"] }
 embassy-stm32 = { version = "0.4", features = [
     "{{ chip_name }}",

--- a/stm32h7b0vb/Cargo.toml
+++ b/stm32h7b0vb/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 rmk = { version = "0.8", features = ["controller"]}
 cortex-m = { version = "0.7.7", features = ['critical-section-single-core'] }
 cortex-m-rt = "0.7.5"
+embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["tick-hz-32_768"] }
 embassy-stm32 = { version = "0.4", features = [
     "{{ chip_name }}",


### PR DESCRIPTION
See also https://github.com/HaoboGu/rmk/pull/689

Using BlockingAsync for the PMW33xx sensors requires the dependency