### PR TITLE
update templates for rp2040 & pico w to work with embassy-boot

### DIFF
--- a/pico_w/Cargo.toml
+++ b/pico_w/Cargo.toml
@@ -11,17 +11,16 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["pico_w_ble", "rp2040"] }
-embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
-embassy-rp = { version = "0.8", features = [
+embassy-rp = { version = "0.10", features = [
     "rp2040",
     "defmt",
     "time-driver",
     "critical-section-impl",
 ] }
-embassy-executor = { version = "0.9", features = [
+embassy-executor = { version = "0.10", features = [
     "defmt",
-    "arch-cortex-m",
+    "platform-cortex-m",
     "executor-thread",
 ] }
 cortex-m-rt = "0.7.5"
@@ -29,19 +28,13 @@ portable-atomic = { version = "1.11", features = ["critical-section"] }
 defmt = "1.0"
 defmt-rtt = "1.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
-cyw43 = { version = "0.5", features = ["defmt", "firmware-logs", "bluetooth"] }
-cyw43-pio = { version = "0.8", features = ["defmt"] }
+cyw43 = { version = "0.7", features = ["defmt", "firmware-logs", "bluetooth"] }
+cyw43-pio = { version = "0.10", features = ["defmt"] }
 static_cell = "2"
-bt-hci = { version = "0.6", default-features = false, features = ["defmt"] }
+bt-hci = { version = "0.8", default-features = false, features = ["defmt"] }
 rand = { version = "0.8.4", default-features = false }
 rand_core = { version = "0.6" }
 rand_chacha = { version = "0.3", default-features = false }
-embassy-usb-driver = "=0.2.0"
-
-[patch.crates-io]
-cyw43 = { git = "https://github.com/embassy-rs/embassy", rev = "faacad6" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", rev = "faacad6" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "faacad6" }
 
 [features]
 skip-cyw43-firmware = []

--- a/pico_w/build.rs
+++ b/pico_w/build.rs
@@ -98,6 +98,7 @@ fn download_cyw43_firmware() {
         "43439A0.bin",
         "43439A0_btfw.bin",
         "43439A0_clm.bin",
+        "nvram_rp2040.bin",
         "LICENSE-permissive-binary-license-1.0.txt",
         "README.md",
     ];

--- a/pico_w_split/Cargo.toml
+++ b/pico_w_split/Cargo.toml
@@ -11,17 +11,16 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["pico_w_ble", "rp2040", "split"] }
-embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
-embassy-rp = { version = "0.8", features = [
+embassy-rp = { version = "0.10", features = [
     "rp2040",
     "defmt",
     "time-driver",
     "critical-section-impl",
 ] }
-embassy-executor = { version = "0.9", features = [
+embassy-executor = { version = "0.10", features = [
     "defmt",
-    "arch-cortex-m",
+    "platform-cortex-m",
     "executor-thread",
 ] }
 cortex-m-rt = "0.7.5"
@@ -29,20 +28,16 @@ portable-atomic = { version = "1.11", features = ["critical-section"] }
 defmt = "1.0"
 defmt-rtt = "1.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
-cyw43 = { version = "0.5", features = ["defmt", "firmware-logs", "bluetooth"] }
-cyw43-pio = { version = "0.8", features = ["defmt"] }
+cyw43 = { version = "0.7", features = ["defmt", "firmware-logs", "bluetooth"] }
+cyw43-pio = { version = "0.10", features = ["defmt"] }
 static_cell = "2"
-bt-hci = { version = "0.6", default-features = false, features = ["defmt"] }
+bt-hci = { version = "0.8", default-features = false, features = ["defmt"] }
 rand = { version = "0.8.4", default-features = false }
 rand_core = { version = "0.6" }
 rand_chacha = { version = "0.3", default-features = false }
-embassy-usb-driver = "=0.2.0"
 
 [features]
 skip-cyw43-firmware = []
-# avoid having to use --allow-multiple-definition linker flag
-# on macOS with Apple Silicon at least
-# default = ["rp-pico/disable-intrinsics"]
 
 [build-dependencies]
 xz2 = "0.1.7"
@@ -73,8 +68,3 @@ debug = true            # no overhead for bare-metal
 opt-level = "z"         # optimize for binary size
 overflow-checks = false
 lto = "fat"
-
-[patch.crates-io]
-cyw43 = { git = "https://github.com/embassy-rs/embassy", rev = "faacad6" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", rev = "faacad6" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "faacad6" }

--- a/rp2040/Cargo.toml
+++ b/rp2040/Cargo.toml
@@ -11,17 +11,16 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["rp2040"] }
-embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
-embassy-rp = { version = "0.8", features = [
+embassy-rp = { version = "0.10", features = [
     "rp2040",
     "defmt",
     "time-driver",
     "critical-section-impl",
 ] }
-embassy-executor = { version = "0.9", features = [
+embassy-executor = { version = "0.10", features = [
     "defmt",
-    "arch-cortex-m",
+    "platform-cortex-m",
     "executor-thread",
 ] }
 cortex-m-rt = "0.7.5"
@@ -29,7 +28,7 @@ portable-atomic = { version = "1.11", features = ["critical-section"] }
 defmt = "1.0"
 defmt-rtt = "1.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
-embassy-usb-driver = "=0.2.0"
+static_cell = "2"
 
 [build-dependencies]
 xz2 = "0.1.7"

--- a/rp2040_split/Cargo.toml
+++ b/rp2040_split/Cargo.toml
@@ -11,27 +11,24 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rmk = { version = "0.8", features = ["split", "rp2040"] }
-embassy-embedded-hal = "0.5.0"
 embassy-time = { version = "0.5", features = ["defmt"] }
-embassy-rp = { version = "0.8", features = [
+embassy-rp = { version = "0.10", features = [
     "rp2040",
     "defmt",
     "time-driver",
     "critical-section-impl",
 ] }
-embassy-executor = { version = "0.9", features = [
+embassy-executor = { version = "0.10", features = [
     "defmt",
-    "arch-cortex-m",
+    "platform-cortex-m",
     "executor-thread",
 ] }
-embassy-futures = { version = "0.1", features = ["defmt"] }
 cortex-m-rt = "0.7.5"
 portable-atomic = { version = "1.11", features = ["critical-section"] }
 defmt = "1.0"
 defmt-rtt = "1.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
 static_cell = "2"
-embassy-usb-driver = "=0.2.0"
 
 [build-dependencies]
 xz2 = "0.1.7"


### PR DESCRIPTION
I updated the rp2040 and pico w templates to make them work with embassy-boot. 