### PR TITLE
fix: name split esp32 firmware images after the keyboard

### DIFF
--- a/esp32c3_split/Makefile.toml
+++ b/esp32c3_split/Makefile.toml
@@ -8,7 +8,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32c3", "--merge", "central.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32c3", "--merge", "{{ project_name }}-central.bin"]
 dependencies = ["build"]
 
 [tasks.save-image-peripheral]
@@ -17,7 +17,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32c3", "--merge", "peripheral.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32c3", "--merge", "{{ project_name }}-peripheral.bin"]
 dependencies = ["build"]
 
 [tasks.uf2]

--- a/esp32c6_split/Makefile.toml
+++ b/esp32c6_split/Makefile.toml
@@ -8,7 +8,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32c6", "--merge", "central.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32c6", "--merge", "{{ project_name }}-central.bin"]
 dependencies = ["build"]
 
 [tasks.save-image-peripheral]
@@ -17,7 +17,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32c6", "--merge", "peripheral.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32c6", "--merge", "{{ project_name }}-peripheral.bin"]
 dependencies = ["build"]
 
 [tasks.uf2]

--- a/esp32h2_split/Makefile.toml
+++ b/esp32h2_split/Makefile.toml
@@ -8,7 +8,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32h2", "--merge", "central.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32h2", "--merge", "{{ project_name }}-central.bin"]
 dependencies = ["build"]
 
 [tasks.save-image-peripheral]
@@ -17,7 +17,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32h2", "--merge", "peripheral.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32h2", "--merge", "{{ project_name }}-peripheral.bin"]
 dependencies = ["build"]
 
 [tasks.uf2]

--- a/esp32s3_split/Makefile.toml
+++ b/esp32s3_split/Makefile.toml
@@ -8,7 +8,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32s3", "--merge", "central.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "central", "--chip", "esp32s3", "--merge", "{{ project_name }}-central.bin"]
 dependencies = ["build"]
 
 [tasks.save-image-peripheral]
@@ -17,7 +17,7 @@ install_crate = { crate_name = "cargo-espflash", binary = "cargo", test_arg = [
     "--help",
 ] }
 command = "cargo"
-args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32s3", "--merge", "peripheral.bin"]
+args = ["espflash", "save-image", "--release", "--bin", "peripheral", "--chip", "esp32s3", "--merge", "{{ project_name }}-peripheral.bin"]
 dependencies = ["build"]
 
 [tasks.uf2]


### PR DESCRIPTION
Split esp32 templates (c3/c6/s3/h2) merged espflash images to hardcoded `central.bin`/`peripheral.bin`, so users building several keyboards get indistinguishable files. Other split templates already follow the `{{ project_name }}-central.uf2` convention, and non-split esp32 templates use `{{ project_name }}.bin`; this aligns the split esp32 templates with them. rmkit substitutes `{{ project_name }}` in all `.toml` files, so `Makefile.toml` is covered.

Reported by @peterjc in https://github.com/peterjc/rmk-pico-keyboards/actions/runs/28672157097/job/85037673964 (esp32h2). Companion workflow fix that actually uploads esp32 `.bin` artifacts: HaoboGu/rmk#903

Verified locally: generated a project from the updated esp32h2_split template (mimicking rmkit substitution) and ran `cargo make uf2 --release` — produced `Fly_Half_ESP32H2-central.bin` and `Fly_Half_ESP32H2-peripheral.bin`.